### PR TITLE
for testing: use a default damage of 0 if a node is not present in SortedDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install -e '.[test]'
 ```
 
 ## Usage
-### Via the python API
+### Via our python module
 Our code utilizes the `python-igraph` library for graph representation. You must first create a graph with that library before executing our code.
 ```
 import node_finder

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -30,18 +30,18 @@ def test_infinity():
 
     # also check that the damage comes out to infinity, as desired
     damages = damage(graph, 0, 5)
-    assert damages[node] == float('inf')
+    assert damages.get(node, default=0) == float('inf')
 
     # check that the damage of node 4 is 1, since the path that passes through node 4
     # is the best one and has influence 4 but there's two more that both have an
     # influence of 5:
     # 5-4 = 1
-    assert damages[4] == 1
+    assert damages.get(4, default=0) == 1
 
     # the damages of nodes 2 and 3 should be 0, since the most influential path doesn't
     # pass through those nodes
-    assert damages[2] == 0
-    assert damages[3] == 0
+    assert damages.get(2, default=0) == 0
+    assert damages.get(3, default=0) == 0
 
 
 # In this graph, any of the nodes could be the most damaging! All should have damage 0
@@ -69,7 +69,7 @@ def test_all_same_damages():
     # also check that each node's damage comes out to 0, as desired
     damages = damage(graph, 0, 5)
     for node in (1, 2, 3, 4):
-        assert damages[node] == 0
+        assert damages.get(node, default=0) == 0
 
 
 # This graph helps test whether our code works for bowtie-like graphs, where two paths
@@ -116,20 +116,20 @@ def test_bowtie():
 
     # also check that the most damage comes out to infinity, as desired
     damages = damage(graph, 0, 7)
-    assert damages[node] == float('inf')
+    assert damages.get(node, default=0) == float('inf')
 
     # check that the damages of nodes 4, 5, and 6 is 1 since the best path passes
     # through those nodes and it has an influence of 4, whereas the next best path has
     # an influence of 5 (because it alternates colors, even though it is shorter)
     # 5-4 = 1
-    assert damages[4] == 1
-    assert damages[5] == 1
+    assert damages.get(4, default=0) == 1
+    assert damages.get(5, default=0) == 1
     assert daamges[6] == 1
 
     # the damage of the other nodes should be 0, since the most influential path
     # doesn't pass through them
-    assert damages[1] == 0
-    assert damages[2] == 0
+    assert damages.get(1, default=0) == 0
+    assert damages.get(2, default=0) == 0
 
     # now, let's try the bowtie!
     node = most_detrimental(graph, 0, 9)
@@ -137,24 +137,24 @@ def test_bowtie():
 
     # also check that the most damage comes out to infinity, as desired
     damages = damage(graph, 0, 9)
-    assert damages[7] == float('inf')
+    assert damages.get(7, default=0) == float('inf')
 
     # check that the damages of node 8 is 1 since the best path passes
     # through that node and it has a total influence of 7, whereas the next best path
     # has an influence of 8 (because it has one alternating node)
     # 8-7 = 1
-    assert damages[8] == 1
+    assert damages.get(8, default=0) == 1
 
     # the damage of the other node should be 0, since the most influential path
     # doesn't pass it
-    assert damages[10] == 0
+    assert damages.get(10, default=0) == 0
 
     # just in case, assert that the damages of the other nodes haven't changed
-    assert damages[1] == 0
-    assert damages[2] == 0
-    assert damages[3] == float('inf')
-    assert damages[4] == 1
-    assert damages[5] == 1
+    assert damages.get(1, default=0) == 0
+    assert damages.get(2, default=0) == 0
+    assert damages.get(3, default=0) == float('inf')
+    assert damages.get(4, default=0) == 1
+    assert damages.get(5, default=0) == 1
     assert daamges[6] == 1
 
 
@@ -190,9 +190,9 @@ def test_cycle():
 
         # also check that the most damage comes out to infinity, as desired
         damages = damage(graph, 0, 3, alpha)
-        assert damages[1] == float('inf')
-        assert damages[2] == float('inf')
+        assert damages.get(1, default=0) == float('inf')
+        assert damages.get(2, default=0) == float('inf')
 
         # and check that the damage of node 4 is 0, since the most influential path
         # should not pass through it!
-        assert damages[4] == 0
+        assert damages.get(4, default=0) == 0

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -81,7 +81,7 @@ def test_two_paths_by_len():
 
     # also check that it calculated the correct damages
     damages = damage(graph, 0, 4)
-    assert damages[node] == (influences[1]-influences[0])
+    assert damages.get(node, default=0) == (influences[1]-influences[0])
 
 
 # Check that the correct path is chosen when there are two possible paths, and one has
@@ -110,7 +110,7 @@ def test_two_paths_by_color():
 
     # also check that it calculated the correct damages
     damages = damage(graph, 0, 3)
-    assert damages[node] == (influences[1]-influences[0])
+    assert damages.get(node, default=0) == (influences[1]-influences[0])
 
 
 # Check that the correct path is chosen when there are two possible paths, and one has
@@ -140,9 +140,9 @@ def test_two_paths_by_len_and_color():
     # also check that it calculated the correct damages
     # they should all be the same (ie 0)
     damages = damage(graph, 0, 4)
-    assert damages[1] == 0
-    assert damages[2] == 0
-    assert damages[3] == 0
+    assert damages.get(1, default=0) == 0
+    assert damages.get(2, default=0) == 0
+    assert damages.get(3, default=0) == 0
 
     # case 2: alpha == 1/2
     node = most_detrimental(graph, 0, 4, alpha=0.5)
@@ -153,7 +153,7 @@ def test_two_paths_by_len_and_color():
     influences = [influence(graph.es['type'][:2], alpha=0.5), influence(graph.es['type'][2:], alpha=0.5)]
     # also check that it calculated the correct damages
     damages = damage(graph, 0, 4, alpha=0.5)
-    assert damages[node] == (influences[1]-influences[0])
+    assert damages.get(node, default=0) == (influences[1]-influences[0])
 
     # case 3: alpha == 2
     node = most_detrimental(graph, 0, 4, alpha=2)
@@ -164,7 +164,7 @@ def test_two_paths_by_len_and_color():
     influences = [influence(graph.es['type'][:2], alpha=2), influence(graph.es['type'][2:], alpha=2)]
     # also check that it calculated the correct damages
     damages = damage(graph, 0, 4, alpha=2)
-    assert damages[node] == (influences[0]-influences[1])
+    assert damages.get(node, default=0) == (influences[0]-influences[1])
 
 
 # Check that the code can correctly ignore stray edges that can't be reached from the


### PR DESCRIPTION
I'm not sure if we need this PR, but I'm including it here just in case. You should merge this only if you don't have all of the damages of every node stored within the final SortedDict at the sink